### PR TITLE
Toggle "[?]" display when meta.description

### DIFF
--- a/jqPropertyGrid.js
+++ b/jqPropertyGrid.js
@@ -167,7 +167,9 @@
 		}
 
 		if (typeof meta.description === 'string' && meta.description) {
-			displayName += '<span class="pgTooltip" title="' + meta.description + '">[?]</span>';
+			if (meta.showhelp !== false) {
+        			displayName += '<span class="pgTooltip" title="' + meta.description + '">[?]</span>';
+            		}
 		}
 
 		return '<tr class="pgRow"><td class="pgCell">' + displayName + '</td><td class="pgCell">' + valueHTML + '</td></tr>';


### PR DESCRIPTION
Added meta.showhelp boolean flag. If it's set to false will not show the [?] span on the property name. i.e. if label type is used and there's a description, I want to see the description on label directly.
